### PR TITLE
feat: add Discord message links to ::recent command

### DIFF
--- a/n8n-workflows/Execute_Command.json
+++ b/n8n-workflows/Execute_Command.json
@@ -1236,7 +1236,6 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false,
-    "timeSavedMode": "fixed",
     "errorWorkflow": "JOXLqn9TTznBdo7Q"
   },
   "staticData": null,

--- a/n8n-workflows/Generate_Activity_Reminder.json
+++ b/n8n-workflows/Generate_Activity_Reminder.json
@@ -106,7 +106,6 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false,
-    "timeSavedMode": "fixed",
     "errorWorkflow": "JOXLqn9TTznBdo7Q"
   },
   "staticData": {

--- a/n8n-workflows/Route_Message.json
+++ b/n8n-workflows/Route_Message.json
@@ -945,7 +945,6 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false,
-    "timeSavedMode": "fixed",
     "errorWorkflow": "JOXLqn9TTznBdo7Q"
   },
   "staticData": null,


### PR DESCRIPTION
## Summary
- Adds clickable Discord message links ([↗]) to `::recent activities` and `::recent notes` output
- Joins projections with events table to fetch `discord_guild_id`, `discord_channel_id`, `discord_message_id`
- Links only appear when Discord IDs are available (graceful fallback)

## Example Output
```
📊 Recent Activities (5)

1. Dec 17 19:24 - **work** - working on the router [↗](discord-link)
2. Dec 17 18:30 - **leisure** - taking a break [↗](discord-link)
...
```