### PR TITLE
fix: add includeOtherFields to Set nodes preserving ctx

### DIFF
--- a/n8n-workflows/Continue_Thread.json
+++ b/n8n-workflows/Continue_Thread.json
@@ -375,7 +375,9 @@
             }
           ]
         },
-        "options": {}
+        "options": {
+          "includeOtherFields": true
+        }
       },
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,

--- a/n8n-workflows/Start_Thread.json
+++ b/n8n-workflows/Start_Thread.json
@@ -325,7 +325,9 @@
             }
           ]
         },
-        "options": {}
+        "options": {
+          "includeOtherFields": true
+        }
       },
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
@@ -382,7 +384,9 @@
             }
           ]
         },
-        "options": {}
+        "options": {
+          "includeOtherFields": true
+        }
       },
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,


### PR DESCRIPTION
## Summary

- Fix Set nodes in thread workflows that were missing `includeOtherFields: true`, which could silently drop ctx fields downstream

## Changes

**Start_Thread.json:**
- "Set llm ctx" node
- "Rebuild Context and Set Inference Start" node

**Continue_Thread.json:**
- "Set LLM Completion" node

## Context

Per AGENTS.md: "Set nodes: **always** enable `includeOtherFields: true` when setting ctx fields"

Without this flag, Set nodes only output the explicitly set fields, dropping everything else in `$json` - including the critical `ctx` object that carries event data through the workflow.

## Testing

- Linter passes: `0 errors, 1 warning` (warning is unrelated to these changes)
- All workflow JSON validates
- Automated reviewer confirmed changes are correct

## Part of

Phase 2 of technical debt cleanup (see `docs/TECH_DEBT_AUDIT.md`)