### PR TITLE
fix: harden shell scripts with set -euo pipefail

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 # Pre-commit hook for Kairon
 # Validates and sanitizes n8n workflow files before commit
 
-set -e
+set -euo pipefail
 
 # Find repo root
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/scripts/db/db-query.sh
+++ b/scripts/db/db-query.sh
@@ -10,7 +10,7 @@
 #   - SSH access configured
 #   - .env file in repo root
 
-set -e
+set -euo pipefail
 
 # Source SSH connection reuse setup
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -62,7 +62,11 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -f)
-            SQL_FILE="$2"
+            SQL_FILE="${2:-}"
+            if [ -z "$SQL_FILE" ]; then
+                echo "❌ Error: -f requires a filename"
+                exit 1
+            fi
             shift 2
             ;;
         -h|--help)

--- a/scripts/db/run-migration.sh
+++ b/scripts/db/run-migration.sh
@@ -10,7 +10,7 @@
 #   - SSH access configured
 #   - .env file in repo root
 
-set -e
+set -euo pipefail
 
 # Source SSH connection reuse setup
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,11 +37,11 @@ for var in REMOTE_HOST CONTAINER_DB DB_USER DB_NAME REMOTE_BACKUP_DIR; do
 done
 
 # --- 4. RESOLVE MIGRATION FILE ---
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
     echo "Usage: $0 <migration_file_or_number>"
     echo ""
     echo "Available migrations:"
-    ls -1 "$REPO_ROOT/db/migrations/"*.sql 2>/dev/null | xargs -n1 basename
+    ls -1 "$REPO_ROOT/db/migrations/"*.sql 2>/dev/null | xargs -n1 basename || echo "  (none found)"
     exit 1
 fi
 

--- a/scripts/workflows/n8n-pull.sh
+++ b/scripts/workflows/n8n-pull.sh
@@ -14,7 +14,7 @@
 #   - SSH access configured (e.g., ~/.ssh/config with Host alias)
 #   - .env file with: REMOTE_HOST, N8N_API_KEY, N8N_API_URL (optional)
 
-set -e
+set -euo pipefail
 
 # Source SSH connection reuse setup
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -125,7 +125,7 @@ while IFS= read -r line; do
             continue
         fi
     elif [ "$EXPORT_ALL" != true ]; then
-        if [ -z "${LOCAL_WORKFLOWS[$name]}" ]; then
+        if [ -z "${LOCAL_WORKFLOWS[$name]:-}" ]; then
             continue
         fi
     fi

--- a/scripts/workflows/n8n-push.sh
+++ b/scripts/workflows/n8n-push.sh
@@ -9,7 +9,7 @@
 #   - SSH access configured (e.g., ~/.ssh/config with Host alias)
 #   - .env file with: REMOTE_HOST, N8N_API_KEY, N8N_API_URL (optional, defaults to http://localhost:5678)
 
-set -e
+set -euo pipefail
 
 # Source SSH connection reuse setup
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,7 +92,7 @@ if [ "$DRY_RUN" = true ]; then
             continue
         fi
         
-        existing_id="${WORKFLOW_IDS[$name]}"
+        existing_id="${WORKFLOW_IDS[$name]:-}"
         
         if [ -n "$existing_id" ]; then
             echo "   [DRY-RUN] Would UPDATE: $name (id: $existing_id)"
@@ -172,7 +172,7 @@ for json_file in "$WORKFLOW_DIR"/*.json; do
         continue
     fi
     
-    existing_id="${WORKFLOW_IDS[$name]}"
+    existing_id="${WORKFLOW_IDS[$name]:-}"
     filename=$(basename "$json_file")
     
     if [ -n "$existing_id" ]; then

--- a/scripts/workflows/sanitize_workflows.sh
+++ b/scripts/workflows/sanitize_workflows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Sanitize n8n workflow exports by removing pinData (test execution data)
 
-set -e
+set -euo pipefail
 
 # Find repo root (works when called from any directory)
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/workflows/validate_workflows.sh
+++ b/scripts/workflows/validate_workflows.sh
@@ -6,7 +6,7 @@
 # If no argument provided, validates all workflows in n8n-workflows/
 # Returns exit code 0 if all valid, 1 if any invalid
 
-set -e
+set -euo pipefail
 
 # Find repo root (works when called from any directory)
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -30,7 +30,7 @@ validate_json() {
 
 has_errors=0
 
-if [ -n "$1" ]; then
+if [ -n "${1:-}" ]; then
     # Validate specific file
     if [ -f "$1" ]; then
         validate_json "$1" || has_errors=1


### PR DESCRIPTION
## Summary

- Add `set -euo pipefail` to all shell scripts to catch errors early and prevent undefined variable bugs

## Changes

**All scripts:**
- `set -e` → `set -euo pipefail`

**Variable safety fixes:**
- `${1:-}` for optional positional arguments
- `${ARRAY[$key]:-}` for associative array lookups
- Error handling for `-f` without argument in db-query.sh
- Fallback for empty migration list in run-migration.sh

## Scripts Updated
- `.githooks/pre-commit`
- `scripts/db/db-query.sh`
- `scripts/db/run-migration.sh`
- `scripts/workflows/n8n-pull.sh`
- `scripts/workflows/n8n-push.sh`
- `scripts/workflows/sanitize_workflows.sh`
- `scripts/workflows/validate_workflows.sh`

## Testing

All scripts tested:
- `n8n-push.sh --dry-run` - passes
- `n8n-pull.sh --dry-run` - passes
- `validate_workflows.sh` - passes
- `run-migration.sh` (usage) - passes
- `db-query.sh -f` (no arg) - proper error

## Part of

Phase 3 of technical debt cleanup (see `docs/TECH_DEBT_AUDIT.md`)