### PR TITLE
feat: projection inspection and quality rating

### DIFF
--- a/n8n-workflows/Handle_Quality_Rating.json
+++ b/n8n-workflows/Handle_Quality_Rating.json
@@ -1,0 +1,145 @@
+{
+  "name": "Handle_Quality_Rating",
+  "nodes": [
+    {
+      "parameters": {
+        "inputSource": "passthrough"
+      },
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [-400, 300],
+      "id": "trigger-quality-rating",
+      "name": "Receive Event"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse quality rating from emoji\nconst ctx = $json.ctx;\nconst emoji = ctx.event.emoji;\n\n// Map emoji to quality score\nconst qualityMap = {\n  '👍': 1.0,\n  '👎': 0.0\n};\n\nconst qualityScore = qualityMap[emoji];\n\nif (qualityScore === undefined) {\n  throw new Error(`Unknown quality emoji: ${emoji}`);\n}\n\nreturn {\n  ctx,\n  quality_score: qualityScore,\n  emoji\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [-180, 300],
+      "id": "parse-quality",
+      "name": "Parse Quality Rating"
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE projections\nSET \n  quality_score = $1,\n  metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(\n    'quality_rated_at', NOW(),\n    'quality_emoji', $2\n  )\nWHERE event_id = (\n  SELECT id FROM events \n  WHERE payload->>'discord_message_id' = $3\n    AND event_type = 'discord_message'\n  ORDER BY received_at DESC\n  LIMIT 1\n)\nAND status IN ('auto_confirmed', 'confirmed')\nRETURNING id, projection_type, quality_score;",
+        "options": {
+          "queryReplacement": "={{ $json.quality_score }},={{ $json.emoji }},={{ $json.ctx.event.message_id }}"
+        }
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.4,
+      "position": [40, 300],
+      "id": "update-quality-score",
+      "name": "Update Quality Score",
+      "alwaysOutputData": true,
+      "credentials": {
+        "postgres": {
+          "id": "MdnYzEgjzWRujz2v",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response based on updated projections\nconst ctx = $('Receive Event').first().json.ctx;\nconst qualityScore = $('Parse Quality Rating').first().json.quality_score;\nconst emoji = $('Parse Quality Rating').first().json.emoji;\nconst updated = $input.all();\n\nif (!updated || updated.length === 0 || !updated[0].json.id) {\n  return {\n    ctx,\n    response: {\n      content: `${emoji} No projections found for this message to rate.`\n    },\n    updated_count: 0\n  };\n}\n\nconst count = updated.length;\nconst types = [...new Set(updated.map(u => u.json.projection_type))];\nconst typeStr = types.join(', ');\nconst scoreLabel = qualityScore === 1.0 ? 'good' : 'poor';\n\nreturn {\n  ctx,\n  response: {\n    content: `${emoji} Marked ${count} projection(s) as **${scoreLabel}** quality (${typeStr})`\n  },\n  updated_count: count\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [260, 300],
+      "id": "format-response",
+      "name": "Format Response"
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "guildId": {
+          "__rl": true,
+          "value": "={{ $json.ctx.event.guild_id }}",
+          "mode": "id"
+        },
+        "channelId": {
+          "__rl": true,
+          "value": "={{ $json.ctx.event.channel_id }}",
+          "mode": "id"
+        },
+        "content": "={{ $json.response.content }}",
+        "options": {
+          "messageReference": "={{ $json.ctx.event.message_id }}"
+        }
+      },
+      "type": "n8n-nodes-base.discord",
+      "typeVersion": 2,
+      "position": [480, 300],
+      "id": "send-response",
+      "name": "Send Response",
+      "webhookId": "quality-rating-response",
+      "retryOnFail": true,
+      "maxTries": 3,
+      "waitBetweenTries": 1000,
+      "credentials": {
+        "discordBotApi": {
+          "id": "hvetTjtpeKFB1V0I",
+          "name": "Discord Bot account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Receive Event": {
+      "main": [
+        [
+          {
+            "node": "Parse Quality Rating",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Quality Rating": {
+      "main": [
+        [
+          {
+            "node": "Update Quality Score",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Quality Score": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Send Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false,
+    "errorWorkflow": "JOXLqn9TTznBdo7Q"
+  },
+  "staticData": null,
+  "meta": null,
+  "active": false
+}

--- a/n8n-workflows/Route_Reaction.json
+++ b/n8n-workflows/Route_Reaction.json
@@ -70,7 +70,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Determine route based on emoji_mapping config\nconst ctx = $('Receive Event').first().json.ctx;\nconst emoji = ctx.event.emoji;\n\n// Parse config - Postgres returns JSON as string\nconst rawValue = $json.value;\nconst config = typeof rawValue === 'string' ? JSON.parse(rawValue) : (rawValue || {});\n\n// Extraction emojis (number selections + dismiss)\n// These are hardcoded because they're tied to display order logic\nconst extractionEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟', '❌'];\n\n// Info emojis (show details about the projection)\nconst infoEmojis = ['❓'];\n\n// Get correction emojis from config (type corrections + void)\nconst corrections = config.corrections || [];\n\n// Get todo status emojis from config\nconst statusEmojis = Object.keys(config.status || {});\n\n// Determine route\nlet route = 'unknown';\n\nif (extractionEmojis.includes(emoji)) {\n  route = 'extraction';\n} else if (infoEmojis.includes(emoji)) {\n  route = 'info';\n} else if (corrections.includes(emoji)) {\n  route = 'correction';\n} else if (statusEmojis.includes(emoji)) {\n  route = 'todo_status';\n}\n\nreturn {\n  ctx,\n  route,\n  emoji,\n  config\n};"
+        "jsCode": "// Determine route based on emoji_mapping config\nconst ctx = $('Receive Event').first().json.ctx;\nconst emoji = ctx.event.emoji;\n\n// Parse config - Postgres returns JSON as string\nconst rawValue = $json.value;\nconst config = typeof rawValue === 'string' ? JSON.parse(rawValue) : (rawValue || {});\n\n// Extraction emojis (number selections + dismiss)\n// These are hardcoded because they're tied to display order logic\nconst extractionEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟', '❌'];\n\n// Info emojis (show details about the projection)\nconst infoEmojis = ['❓'];\n\n// Quality rating emojis (rate projection quality)\nconst qualityEmojis = ['👍', '👎'];\n\n// Get correction emojis from config (type corrections + void)\nconst corrections = config.corrections || [];\n\n// Get todo status emojis from config\nconst statusEmojis = Object.keys(config.status || {});\n\n// Determine route\nlet route = 'unknown';\n\nif (extractionEmojis.includes(emoji)) {\n  route = 'extraction';\n} else if (infoEmojis.includes(emoji)) {\n  route = 'info';\n} else if (qualityEmojis.includes(emoji)) {\n  route = 'quality';\n} else if (corrections.includes(emoji)) {\n  route = 'correction';\n} else if (statusEmojis.includes(emoji)) {\n  route = 'todo_status';\n}\n\nreturn {\n  ctx,\n  route,\n  emoji,\n  config\n};"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -132,6 +132,30 @@
               },
               "renameOutput": true,
               "outputKey": "Info"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "is-quality",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "quality",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "Quality"
             },
             {
               "conditions": {
@@ -274,7 +298,7 @@
       "typeVersion": 1,
       "position": [
         720,
-        960
+        1040
       ],
       "id": "unknown-emoji-error",
       "name": "Unknown Emoji Error"
@@ -302,6 +326,30 @@
       ],
       "id": "show-projection-details",
       "name": "Show Projection Details"
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "value": "XmanM922rwHz8e7X",
+          "mode": "id"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {}
+        },
+        "options": {
+          "waitForSubWorkflow": false
+        }
+      },
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [
+        720,
+        880
+      ],
+      "id": "handle-quality-rating",
+      "name": "Handle Quality Rating"
     }
   ],
   "connections": {
@@ -361,6 +409,13 @@
         [
           {
             "node": "Show Projection Details",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Handle Quality Rating",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- Add ❔/❓ reactions to inspect projections (simple vs detailed view)
- Add 👍/👎 reactions to rate projection quality
- Store full rendered prompts in all LLM workflow traces

## Changes

### Projection Inspection
- ❔ (grey): Simple view - just shows saved projections with emoji + text
- ❓ (red): Detailed view - full prompts, timing, links to original message
- Fixed: Bot reply projections now found via `data.discord_message_id`

### Quality Rating (untested)
- 👍 sets quality_score=1.0, 👎 sets quality_score=0.0
- New workflow: `Handle_Quality_Rating.json`

### Full Prompt Storage
All LLM workflows now store the exact rendered prompt in `traces.data.prompt`:
- Multi_Capture, Capture_Projection, Generate_Nudge, Generate_Daily_Summary
- Continue_Thread, Capture_Thread

This enables debugging LLM behavior via the ❓ reaction.