### PR TITLE
feat: add Query_DB sub-workflow for batch database queries

### DIFF
--- a/n8n-workflows-dev/Smoke_Test.json
+++ b/n8n-workflows-dev/Smoke_Test.json
@@ -68,6 +68,44 @@
     },
     {
       "parameters": {
+        "jsCode": "// Prepare ctx for Query_DB test\nconst state = $json;\nreturn [{\n  json: {\n    _state: state,\n    ctx: {\n      event: { event_id: 'smoke-test' },\n      db_queries: [\n        { key: 'test1', sql: 'SELECT 1 as value' },\n        { key: 'test2', sql: 'SELECT 2 as value' }\n      ]\n    }\n  }\n}];"
+      },
+      "id": "smoke-prep-query-db",
+      "name": "Prepare Query_DB",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 0]
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "mode": "id",
+          "value": "QXmBwl6dvPbW001h"
+        },
+        "options": {
+          "waitForSubWorkflow": true
+        }
+      },
+      "id": "smoke-query-db",
+      "name": "Call Query_DB",
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [1320, 0],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "// Evaluate Query_DB result\nconst input = $json;\n\n// Handle error case\nif (input.error) {\n  const state = $('Prepare Query_DB').first().json._state;\n  state.tests.push({ \n    name: 'query_db', \n    passed: false, \n    details: 'Query_DB failed: ' + (input.error.message || JSON.stringify(input.error))\n  });\n  return [{ json: state }];\n}\n\n// Check ctx.db has our query results\nconst ctx = input.ctx;\nconst test1Ok = ctx?.db?.test1?.results?.[0]?.value === 1;\nconst test2Ok = ctx?.db?.test2?.results?.[0]?.value === 2;\nconst passed = test1Ok && test2Ok;\n\nconst state = $('Prepare Query_DB').first().json._state;\nstate.tests.push({ \n  name: 'query_db', \n  passed, \n  details: passed ? 'OK' : `test1=${test1Ok}, test2=${test2Ok}`\n});\n\nreturn [{ json: state }];"
+      },
+      "id": "smoke-eval-query-db",
+      "name": "Evaluate Query_DB",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1540, 0]
+    },
+    {
+      "parameters": {
         "operation": "executeQuery",
         "query": "DELETE FROM config WHERE key LIKE 'smoke_test_%'",
         "options": {}
@@ -76,7 +114,7 @@
       "name": "Cleanup",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.4,
-      "position": [1100, 0],
+      "position": [1760, 0],
       "credentials": {
         "postgres": {
           "name": "Postgres account"
@@ -86,13 +124,13 @@
     },
     {
       "parameters": {
-        "jsCode": "const state = $('Evaluate').first().json;\nconst passed = state.tests.filter(t => t.passed).length;\nconst failed = state.tests.filter(t => !t.passed).length;\nreturn [{ json: {\n  success: failed === 0,\n  message: failed === 0 ? `All ${passed} tests passed` : `${failed} failed`,\n  run_id: state.run_id,\n  summary: { total: state.tests.length, passed, failed },\n  tests: state.tests\n}}];"
+        "jsCode": "const state = $('Evaluate Query_DB').first().json;\nconst passed = state.tests.filter(t => t.passed).length;\nconst failed = state.tests.filter(t => !t.passed).length;\nreturn [{ json: {\n  success: failed === 0,\n  message: failed === 0 ? `All ${passed} tests passed` : `${failed} failed`,\n  run_id: state.run_id,\n  summary: { total: state.tests.length, passed, failed },\n  tests: state.tests\n}}];"
       },
       "id": "smoke-compile",
       "name": "Compile",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1320, 0]
+      "position": [1980, 0]
     },
     {
       "parameters": {
@@ -103,7 +141,7 @@
       "name": "Return",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1540, 0]
+      "position": [2200, 0]
     }
   ],
   "connections": {
@@ -123,6 +161,15 @@
       "main": [[{"node": "Evaluate", "type": "main", "index": 0}]]
     },
     "Evaluate": {
+      "main": [[{"node": "Prepare Query_DB", "type": "main", "index": 0}]]
+    },
+    "Prepare Query_DB": {
+      "main": [[{"node": "Call Query_DB", "type": "main", "index": 0}]]
+    },
+    "Call Query_DB": {
+      "main": [[{"node": "Evaluate Query_DB", "type": "main", "index": 0}]]
+    },
+    "Evaluate Query_DB": {
       "main": [[{"node": "Cleanup", "type": "main", "index": 0}]]
     },
     "Cleanup": {

--- a/n8n-workflows/Query_DB.json
+++ b/n8n-workflows/Query_DB.json
@@ -1,0 +1,236 @@
+{
+  "name": "Query_DB",
+  "nodes": [
+    {
+      "parameters": {
+        "inputSource": "passthrough"
+      },
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "trigger-execute-query",
+      "name": "Execute Workflow Trigger"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input and initialize loop state\nconst ctx = $json.ctx;\n\nif (!ctx?.db_queries || !Array.isArray(ctx.db_queries) || ctx.db_queries.length === 0) {\n  throw new Error('Query_DB requires ctx.db_queries array with at least one query');\n}\n\n// Validate each query has required fields\nfor (const q of ctx.db_queries) {\n  if (!q.key || !q.sql) {\n    throw new Error('Each query in ctx.db_queries must have key and sql fields');\n  }\n}\n\n// Initialize loop state\nreturn [{\n  json: {\n    original_ctx: ctx,\n    queries: ctx.db_queries,\n    current_index: 0,\n    results: {}  // Will accumulate {key: {results, count}}\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        0
+      ],
+      "id": "initialize-loop",
+      "name": "Initialize Loop"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare current query for execution\nconst state = $json;\nconst query = state.queries[state.current_index];\n\nreturn [{\n  json: {\n    ...state,\n    current_query: query,\n    sql: query.sql,\n    params: query.params || []\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        440,
+        0
+      ],
+      "id": "prepare-query",
+      "name": "Prepare Query"
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "={{ $json.sql }}",
+        "options": {
+          "queryReplacement": "={{ $json.params }}"
+        }
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.4,
+      "position": [
+        660,
+        0
+      ],
+      "id": "execute-postgres-query",
+      "name": "Execute Query",
+      "credentials": {
+        "postgres": {
+          "name": "Postgres account"
+        }
+      },
+      "alwaysOutputData": true
+    },
+    {
+      "parameters": {
+        "mode": "append",
+        "numberInputs": 2,
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [
+        880,
+        0
+      ],
+      "id": "merge-results",
+      "name": "Merge Results"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Collect query results and check if more queries remain\nconst items = $input.all();\n\n// Find state from merge (has original_ctx)\nlet state = null;\nconst queryResults = [];\n\nfor (const item of items) {\n  if (item.json.original_ctx) {\n    state = item.json;\n  } else {\n    // This is a Postgres result row\n    queryResults.push(item.json);\n  }\n}\n\nif (!state) {\n  throw new Error('Query_DB: Lost loop state');\n}\n\n// Store results for current query\nconst currentKey = state.current_query.key;\nstate.results[currentKey] = {\n  results: queryResults,\n  count: queryResults.length\n};\n\n// Move to next query\nstate.current_index++;\n\n// Check if more queries remain\nconst hasMore = state.current_index < state.queries.length;\n\nreturn [{\n  json: {\n    ...state,\n    has_more: hasMore\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1100,
+        0
+      ],
+      "id": "collect-results",
+      "name": "Collect Results"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-more",
+              "leftValue": "={{ $json.has_more }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        1320,
+        0
+      ],
+      "id": "check-more-queries",
+      "name": "More Queries?"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Restore ctx with all query results in ctx.db namespace\nconst state = $json;\n\n// Remove db_queries since it was consumed\nconst { db_queries, ...restCtx } = state.original_ctx;\n\nreturn [{\n  json: {\n    ctx: {\n      ...restCtx,\n      db: {\n        ...(restCtx.db || {}),\n        ...state.results\n      }\n    }\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1540,
+        100
+      ],
+      "id": "finalize-context",
+      "name": "Finalize Context"
+    }
+  ],
+  "connections": {
+    "Execute Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Initialize Loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Initialize Loop": {
+      "main": [
+        [
+          {
+            "node": "Prepare Query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Query": {
+      "main": [
+        [
+          {
+            "node": "Execute Query",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Execute Query": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Results": {
+      "main": [
+        [
+          {
+            "node": "Collect Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Collect Results": {
+      "main": [
+        [
+          {
+            "node": "More Queries?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "More Queries?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Query",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Finalize Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `Query_DB` sub-workflow infrastructure for standardized batch database queries. This is the first step of an incremental migration from the large PR #36 which broke prod.

## Changes

- **Query_DB.json** - Reusable sub-workflow that:
  - Accepts `ctx.db_queries` array with `{key, sql, params}` objects
  - Executes queries sequentially in a loop
  - Returns results in `ctx.db[key] = {results, count}` structure
  - Preserves ctx throughout

- **Smoke_Test.json** - Added Query_DB test to validate the batch query pattern

## Usage

```javascript
// In a Code node, prepare ctx.db_queries:
return [{
  json: {
    ctx: {
      ...existingCtx,
      db_queries: [
        { key: 'north_star', sql: "SELECT value FROM config WHERE key = 'north_star'" },
        { key: 'activities', sql: 'SELECT * FROM projections WHERE projection_type = $1 LIMIT 20', params: ['activity'] }
      ]
    }
  }
}];

// After Query_DB returns, access results via ctx.db:
const northStar = ctx.db.north_star.results[0]?.value;
const activities = ctx.db.activities.results;
```

## Migration Strategy

This PR only adds the infrastructure. Workflow migrations will be done incrementally in follow-up PRs:

1. **Continue_Thread** - Has 4 parallel SELECTs → 1 Query_DB call
2. **Multi_Capture** - Similar pattern
3. **Generate_Daily_Summary** - 5+ SELECTs
4. etc.

Each migration will be tested in dev before merging to main.

## Why Incremental?

PR #36 attempted to migrate all workflows at once. A bug in Handle_Error caused an infinite loop that took down the server. See `docs/postmortem-2025-12-22-error-cascade.md` in that branch.

This incremental approach:
- Tests each migration in the dev environment first
- Keeps changes small and reviewable
- Reduces blast radius if something goes wrong

## Testing

- ✅ Deployed to dev
- ✅ Smoke tests pass (including new Query_DB test)