### PR TITLE
refactor: migrate Start_Thread to Execute_Queries and simplify

### DIFF
--- a/n8n-workflows/Start_Thread.json
+++ b/n8n-workflows/Start_Thread.json
@@ -29,7 +29,7 @@
       "typeVersion": 4.2,
       "position": [
         18720,
-        -2464
+        -2320
       ],
       "id": "85fce562-824f-47c1-83cf-ea4d7e807ea4",
       "name": "Create Discord Thread",
@@ -45,38 +45,16 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "SELECT value FROM config WHERE key = 'north_star';",
-        "options": {}
-      },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
-      "position": [
-        18720,
-        -2176
-      ],
-      "id": "14297959-30b4-415d-b84e-c44604749da7",
-      "name": "Get North Star",
-      "alwaysOutputData": true,
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      }
-    },
-    {
-      "parameters": {
         "promptType": "define",
-        "text": "=You are an AI life coach helping the user reflect, plan, and think deeply.\n\n## Context Available\n\n**User's Guiding Principle:** {{ $json.ctx.db.north_star }}\n\nKeep this in mind when helping them, but don't mention it unless directly relevant to the conversation.\n\n## Current Situation\n\nThe user just started a conversation thread with: {{ $json.ctx.event.clean_text }}\n\nThey are coming to you for help thinking through something.\n\n## Instructions\n\n**Assess the question type:**\n\n**Simple/direct question** (what's X?, how do I Y?) → Answer directly if you can. Be concise (2-3 sentences).\n\n**Planning/reflection/decision** (what should I focus on?, help me think about X) → Signal that you're gathering context, then ask 1 clarifying question. Total 2-3 sentences.\n\n## Style\n\n- Warm and conversational\n- Natural and specific to their words\n- Not robotic or generic\n- Don't force connections to the guiding principle\n- Focus on what they're asking, not on fitting everything into a grand narrative\n\n## Example Responses (for planning/reflection questions)\n\n**User:** what should I focus on today?\n**Good response:** Let me check what you've been working on lately. Are you thinking about what to prioritize right now, or planning for the whole day?\n\n**User:** help me think through this project decision\n**Good response:** I'll look at your recent activities to give you a grounded perspective. What's the core tradeoff you're trying to navigate?\n\n**User:** feeling scattered, what's going on?\n**Good response:** Let me pull up your week so far. When did you first notice feeling scattered - today or has it been building?\n\n**User:** am I making progress on my goals?\n**Good response:** Looking at your recent work to see the patterns. Which goal are you most curious about?\n\nNotice how each response:\n1. Signals gathering context in a natural, varied way\n2. Asks a clarifying question that's conversational and specific, not generic\n\nRespond to their initial message now.",
+        "text": "=You are an AI life coach helping the user reflect, plan, and think deeply.\n\n## Context Available\n\n**User's Guiding Principle:** {{ $json.ctx.db.north_star }}\n\nKeep this in mind when helping them, but don't mention it unless directly relevant to the conversation.\n\n## Current Situation\n\nThe user just started a conversation thread with: {{ $json.ctx.event.clean_text }}\n\nThey are coming to you for help thinking through something.\n\n## Instructions\n\n**Assess the question type:**\n\n**Simple/direct question** (what's X?, how do I Y?) \u2192 Answer directly if you can. Be concise (2-3 sentences).\n\n**Planning/reflection/decision** (what should I focus on?, help me think about X) \u2192 Signal that you're gathering context, then ask 1 clarifying question. Total 2-3 sentences.\n\n## Style\n\n- Warm and conversational\n- Natural and specific to their words\n- Not robotic or generic\n- Don't force connections to the guiding principle\n- Focus on what they're asking, not on fitting everything into a grand narrative\n\n## Example Responses (for planning/reflection questions)\n\n**User:** what should I focus on today?\n**Good response:** Let me check what you've been working on lately. Are you thinking about what to prioritize right now, or planning for the whole day?\n\n**User:** help me think through this project decision\n**Good response:** I'll look at your recent activities to give you a grounded perspective. What's the core tradeoff you're trying to navigate?\n\n**User:** feeling scattered, what's going on?\n**Good response:** Let me pull up your week so far. When did you first notice feeling scattered - today or has it been building?\n\n**User:** am I making progress on my goals?\n**Good response:** Looking at your recent work to see the patterns. Which goal are you most curious about?\n\nNotice how each response:\n1. Signals gathering context in a natural, varied way\n2. Asks a clarifying question that's conversational and specific, not generic\n\nRespond to their initial message now.",
         "needsFallback": true,
         "batching": {}
       },
       "type": "@n8n/n8n-nodes-langchain.chainLlm",
       "typeVersion": 1.7,
       "position": [
-        19392,
-        -2196
+        19616,
+        -2320
       ],
       "id": "f6f390a8-c453-4cee-8d6d-2b9a415e3a29",
       "name": "Generate Initial Response"
@@ -91,8 +69,8 @@
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenRouter",
       "typeVersion": 1,
       "position": [
-        19400,
-        -1972
+        19624,
+        -2096
       ],
       "id": "0c6a309d-86ff-4aa3-b02f-33230ae4f092",
       "name": "nemotron-nano-9b",
@@ -113,8 +91,8 @@
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenRouter",
       "typeVersion": 1,
       "position": [
-        19528,
-        -1972
+        19752,
+        -2096
       ],
       "id": "60963dec-c78a-4918-8b32-12e1a0f25d8b",
       "name": "mimo-v2-flash",
@@ -127,31 +105,16 @@
     },
     {
       "parameters": {
-        "mode": "combine",
-        "combineBy": "combineByPosition",
-        "options": {}
-      },
-      "type": "n8n-nodes-base.merge",
-      "typeVersion": 3,
-      "position": [
-        19968,
-        -2320
-      ],
-      "id": "merge-llm-result",
-      "name": "Merge LLM Result"
-    },
-    {
-      "parameters": {
-        "jsCode": "// Prepare data for trace and projection storage\nconst ctx = $json.ctx || {};\n\nconst response = ctx.llm?.completion_text || '';\nconst inferenceStart = ctx.llm?.inference_start || Date.now();\nconst durationMs = Date.now() - inferenceStart;\n\n// Build filled prompt (reconstructed from template)\nconst northStar = ctx.llm?.north_star || '(not set)';\nconst cleanText = ctx.event?.clean_text || '';\nconst promptText = `You are an AI life coach...\\n\\nUser's Guiding Principle: ${northStar}\\n\\nThe user started with: ${cleanText}`;\n\n// Format trace_chain for PostgreSQL uuid[] type\nconst traceChain = ctx.event?.trace_chain || [];\nconst traceChainPg = '{' + traceChain.join(',') + '}';\n\nreturn [{\n  json: {\n    ctx: ctx,\n    // Data for trace insert\n    event_id: ctx.event?.event_id,\n    event_timestamp: ctx.event?.timestamp,\n    input_text: cleanText,\n    input_thread_id: ctx.thread?.id,\n    prompt_text: promptText,\n    completion_text: response,\n    result_response_length: response.length,\n    duration_ms: durationMs,\n    trace_chain_pg: traceChainPg\n  }\n}];"
+        "jsCode": "// Prepare db_queries for trace + projection storage\nconst ctx = $json.ctx || {};\n\nconst response = ctx.llm?.completion_text || '';\nconst inferenceStart = ctx.llm?.inference_start || Date.now();\nconst durationMs = Date.now() - inferenceStart;\n\n// Build filled prompt (reconstructed from template)\nconst northStar = ctx.llm?.north_star || '(not set)';\nconst cleanText = ctx.event?.clean_text || '';\nconst promptText = `You are an AI life coach...\\n\\nUser's Guiding Principle: ${northStar}\\n\\nThe user started with: ${cleanText}`;\n\n// Prepare db_queries for Execute_Queries\nconst db_queries = [\n  {\n    key: 'trace',\n    sql: `WITH new_trace AS (\n            INSERT INTO traces (event_id, step_name, data, trace_chain)\n            VALUES ($1::uuid, 'thread_initial_response',\n              jsonb_build_object(\n                'input', jsonb_build_object('text', $2, 'thread_id', $3::text),\n                'prompt', $4,\n                'completion', $5,\n                'result', jsonb_build_object('response_length', $6::integer),\n                'model', 'nvidia/nemotron-nano-9b-v2:free',\n                'duration_ms', $7::integer\n              ), $8::uuid[])\n            RETURNING id\n          )\n          SELECT new_trace.id as trace_id, $8::uuid[] || new_trace.id as updated_trace_chain\n          FROM new_trace`,\n    params: [\n      ctx.event?.event_id,\n      cleanText,\n      ctx.thread?.id,\n      promptText,\n      response,\n      response.length,\n      durationMs,\n      ctx.event?.trace_chain || []\n    ]\n  },\n  {\n    key: 'projection',\n    sql: `INSERT INTO projections (event_id, trace_id, trace_chain, projection_type, status, data, timezone)\n          VALUES ($1::uuid, $2::uuid, $3::uuid[], 'thread_response', 'auto_confirmed',\n            jsonb_build_object(\n              'thread_id', $4,\n              'response_text', $5,\n              'role', 'assistant',\n              'timestamp', $6::timestamptz\n            ), $7)\n          RETURNING id`,\n    params: [\n      ctx.event?.event_id,\n      '$results.trace.row.trace_id',\n      '$results.trace.row.updated_trace_chain',\n      ctx.thread?.id,\n      response,\n      ctx.event?.timestamp,\n      ctx.event?.timezone\n    ]\n  }\n];\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      db_queries\n    }\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        20192,
-        -2224
+        20288,
+        -2320
       ],
-      "id": "fbff38ac-ebf5-48aa-8666-8117b8d13d0e",
-      "name": "Prepare Trace Data"
+      "id": "prepare-write-queries",
+      "name": "Prepare Write Queries"
     },
     {
       "parameters": {
@@ -172,8 +135,8 @@
       "type": "n8n-nodes-base.discord",
       "typeVersion": 2,
       "position": [
-        20192,
-        -2416
+        20064,
+        -2320
       ],
       "id": "a5785f29-feef-42f4-8da5-d5eaeb9fd055",
       "name": "Send Response to Thread",
@@ -203,16 +166,16 @@
           "mode": "id"
         },
         "messageId": "={{ $json.ctx.event.message_id }}",
-        "emoji": "=🗨️"
+        "emoji": "=\ud83d\udde8\ufe0f"
       },
       "type": "n8n-nodes-base.discord",
       "typeVersion": 2,
       "position": [
         18720,
-        -2656
+        -2560
       ],
       "id": "1e7b0d2a-54ee-4607-bcd9-7872585cb7c1",
-      "name": "React with 🗨️",
+      "name": "React with \ud83d\udde8\ufe0f",
       "webhookId": "d9babcdf-8243-4adb-83c8-bbaf038fbfc7",
       "retryOnFail": true,
       "maxTries": 3,
@@ -228,7 +191,7 @@
     {
       "parameters": {
         "method": "DELETE",
-        "url": "=https://discord.com/api/v10/channels/{{ $json.ctx.event.channel_id }}/messages/{{ $json.ctx.event.message_id }}/reactions/🔵/@me",
+        "url": "=https://discord.com/api/v10/channels/{{ $json.ctx.event.channel_id }}/messages/{{ $json.ctx.event.message_id }}/reactions/\ud83d\udd35/@me",
         "authentication": "predefinedCredentialType",
         "nodeCredentialType": "discordBotApi",
         "options": {}
@@ -237,10 +200,10 @@
       "typeVersion": 4.2,
       "position": [
         18720,
-        -1984
+        -2080
       ],
       "id": "remove-blue-reaction-start-chat",
-      "name": "Remove 🔵 Reaction",
+      "name": "Remove \ud83d\udd35 Reaction",
       "retryOnFail": true,
       "maxTries": 3,
       "waitBetweenTries": 1000,
@@ -254,148 +217,76 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "WITH new_trace AS (\n  INSERT INTO traces (event_id, step_name, data, trace_chain)\n  VALUES (\n    $1::uuid,\n    'thread_initial_response',\n    jsonb_build_object(\n      'input', jsonb_build_object(\n        'text', $2,\n        'thread_id', $3::text\n      ),\n      'prompt', $4,\n      'completion', $5,\n      'result', jsonb_build_object(\n        'response_length', $6::integer\n      ),\n      'model', 'nvidia/nemotron-nano-9b-v2:free',\n      'duration_ms', $7::integer\n    ),\n    $8::uuid[]\n  )\n  RETURNING id\n)\nSELECT \n  new_trace.id as trace_id,\n  $8::uuid[] || new_trace.id as updated_trace_chain\nFROM new_trace;",
-        "options": {
-          "queryReplacement": "={{ $json.event_id }},={{ $json.input_text }},={{ $json.input_thread_id }},={{ $json.prompt_text }},={{ $json.completion_text }},={{ $json.result_response_length }},={{ $json.duration_ms }},={{ $json.trace_chain_pg }}"
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
         }
       },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.2,
       "position": [
-        20416,
-        -2296
+        20512,
+        -2320
       ],
-      "id": "b1b95f53-19af-4782-a1d7-6204f58efaca",
-      "name": "Write Thread Initial Trace",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      }
+      "id": "execute-write-queries",
+      "name": "Execute_Queries (Write)"
     },
     {
       "parameters": {
-        "mode": "combine",
-        "combineBy": "combineByPosition",
-        "options": {}
+        "jsCode": "// Prepare north_star query and build initial ctx\nconst triggerData = $json;\nconst ctx = triggerData.ctx || {};\n\nconst db_queries = [\n  {\n    key: 'north_star',\n    sql: \"SELECT value FROM config WHERE key = 'north_star'\"\n  }\n];\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      db_queries\n    }\n  }\n}];"
       },
-      "type": "n8n-nodes-base.merge",
-      "typeVersion": 3,
-      "position": [
-        20640,
-        -2224
-      ],
-      "id": "merge-trace-result",
-      "name": "Merge Trace Result"
-    },
-    {
-      "parameters": {
-        "operation": "executeQuery",
-        "query": "INSERT INTO projections (\n  event_id,\n  trace_id,\n  trace_chain,\n  projection_type,\n  status,\n  data,\n  timezone\n)\nVALUES (\n  $1::uuid,\n  $2::uuid,\n  $3::uuid[],\n  'thread_response',\n  'auto_confirmed',\n  jsonb_build_object(\n    'thread_id', $4,\n    'response_text', $5,\n    'role', 'assistant',\n    'timestamp', $6::timestamptz\n  ),\n  $7\n)\nRETURNING id;",
-        "options": {
-          "queryReplacement": "={{ $json.event_id }},={{ $json.trace_id }},={{ $json.updated_trace_chain }},={{ $json.ctx.thread.id }},={{ $json.ctx.llm.completion_text }},={{ $json.ctx.event.timestamp }},={{ $json.ctx.event.timezone }}"
-        }
-      },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
-      "position": [
-        20864,
-        -2224
-      ],
-      "id": "store-response-projection",
-      "name": "Store Response Projection",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      }
-    },
-    {
-      "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "5e8ab96e-bc97-4681-91fd-51e42f74cb1e",
-              "name": "ctx.llm.completion_text",
-              "value": "={{ $json.text }}",
-              "type": "string"
-            }
-          ]
-        },
-        "options": {
-          "includeOtherFields": true
-        }
-      },
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        19744,
-        -2196
-      ],
-      "id": "dde6b5fe-f9d0-48e0-87c9-9e7160c142e3",
-      "name": "Set llm ctx"
-    },
-    {
-      "parameters": {
-        "mode": "combine",
-        "combineBy": "combineByPosition",
-        "numberInputs": 3,
-        "options": {}
-      },
-      "type": "n8n-nodes-base.merge",
-      "typeVersion": 3,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
         18944,
-        -2336
+        -2320
       ],
-      "id": "54301339-2cc0-447e-92ff-0c0fc46ccb87",
-      "name": "Merge Thread + North Star"
+      "id": "prepare-read-queries",
+      "name": "Prepare Read Queries"
     },
     {
       "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "b3356692-b0a6-4416-9d7a-3d49fcfbe6d1",
-              "name": "ctx.event",
-              "value": "={{ $json.ctx.event }}",
-              "type": "object"
-            },
-            {
-              "id": "start-time",
-              "name": "ctx.llm.inference_start",
-              "value": "={{ Date.now() }}",
-              "type": "number"
-            },
-            {
-              "id": "7d2f06f3-82d2-47cb-94ac-2d8929e2879c",
-              "name": "ctx.db.north_star",
-              "value": "={{ $json.value }}",
-              "type": "string"
-            },
-            {
-              "id": "eade12b1-869a-4656-8b5d-10a53e69cff9",
-              "name": "ctx.thread.id",
-              "value": "={{ $json.id }}",
-              "type": "string"
-            }
-          ]
-        },
-        "options": {
-          "includeOtherFields": true
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
         }
       },
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.2,
       "position": [
         19168,
         -2320
       ],
-      "id": "0abfd7cc-9559-48da-a48b-c8b6c1d5d853",
-      "name": "Rebuild Context and Set Inference Start"
+      "id": "execute-read-queries",
+      "name": "Execute_Queries (Read)"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build context for LLM from thread and db results\nconst ctx = $json.ctx || {};\nconst threadData = $('Create Discord Thread').first().json;\n\n// Get north_star from Execute_Queries result\nconst northStar = ctx.db?.north_star?.row?.value || '(not set)';\n\n// Preserve all ctx.event fields and add thread + llm context\nreturn [{\n  json: {\n    ctx: {\n      event: {\n        event_id: ctx.event?.event_id,\n        channel_id: ctx.event?.channel_id,\n        message_id: ctx.event?.message_id,\n        guild_id: ctx.event?.guild_id,\n        clean_text: ctx.event?.clean_text,\n        timestamp: ctx.event?.timestamp,\n        timezone: ctx.event?.timezone,\n        trace_chain: ctx.event?.trace_chain\n      },\n      thread: {\n        id: threadData.id\n      },\n      db: {\n        north_star: northStar\n      },\n      llm: {\n        inference_start: Date.now(),\n        north_star: northStar\n      }\n    }\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        19392,
+        -2320
+      ],
+      "id": "build-llm-context",
+      "name": "Build LLM Context"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Add LLM response to ctx\nconst prevData = $('Build LLM Context').first().json;\nconst ctx = prevData.ctx;\nconst llmResponse = $json.text || '';\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      llm: {\n        ...ctx.llm,\n        completion_text: llmResponse\n      }\n    }\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        19840,
+        -2320
+      ],
+      "id": "set-llm-response",
+      "name": "Set LLM Response"
     }
   ],
   "connections": {
@@ -408,24 +299,14 @@
             "index": 0
           },
           {
-            "node": "Get North Star",
+            "node": "React with \ud83d\udde8\ufe0f",
             "type": "main",
             "index": 0
           },
           {
-            "node": "React with 🗨️",
+            "node": "Remove \ud83d\udd35 Reaction",
             "type": "main",
             "index": 0
-          },
-          {
-            "node": "Remove 🔵 Reaction",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Merge Thread + North Star",
-            "type": "main",
-            "index": 1
           }
         ]
       ]
@@ -434,20 +315,42 @@
       "main": [
         [
           {
-            "node": "Merge Thread + North Star",
+            "node": "Prepare Read Queries",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Get North Star": {
+    "Prepare Read Queries": {
       "main": [
         [
           {
-            "node": "Merge Thread + North Star",
+            "node": "Execute_Queries (Read)",
             "type": "main",
-            "index": 2
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute_Queries (Read)": {
+      "main": [
+        [
+          {
+            "node": "Build LLM Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build LLM Context": {
+      "main": [
+        [
+          {
+            "node": "Generate Initial Response",
+            "type": "main",
+            "index": 0
           }
         ]
       ]
@@ -456,11 +359,54 @@
       "main": [
         [
           {
-            "node": "Set llm ctx",
+            "node": "Set LLM Response",
             "type": "main",
             "index": 0
           }
         ]
+      ]
+    },
+    "Set LLM Response": {
+      "main": [
+        [
+          {
+            "node": "Send Response to Thread",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Response to Thread": {
+      "main": [
+        [
+          {
+            "node": "Prepare Write Queries",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Write Queries": {
+      "main": [
+        [
+          {
+            "node": "Execute_Queries (Write)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "React with \ud83d\udde8\ufe0f": {
+      "main": [
+        []
+      ]
+    },
+    "Remove \ud83d\udd35 Reaction": {
+      "main": [
+        []
       ]
     },
     "nemotron-nano-9b": {
@@ -481,108 +427,6 @@
             "node": "Generate Initial Response",
             "type": "ai_languageModel",
             "index": 1
-          }
-        ]
-      ]
-    },
-    "Merge LLM Result": {
-      "main": [
-        [
-          {
-            "node": "Send Response to Thread",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Prepare Trace Data",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Prepare Trace Data": {
-      "main": [
-        [
-          {
-            "node": "Write Thread Initial Trace",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Merge Trace Result",
-            "type": "main",
-            "index": 1
-          }
-        ]
-      ]
-    },
-    "Write Thread Initial Trace": {
-      "main": [
-        [
-          {
-            "node": "Merge Trace Result",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Merge Trace Result": {
-      "main": [
-        [
-          {
-            "node": "Store Response Projection",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Send Response to Thread": {
-      "main": [
-        []
-      ]
-    },
-    "React with 🗨️": {
-      "main": [
-        []
-      ]
-    },
-    "Set llm ctx": {
-      "main": [
-        [
-          {
-            "node": "Merge LLM Result",
-            "type": "main",
-            "index": 1
-          }
-        ]
-      ]
-    },
-    "Merge Thread + North Star": {
-      "main": [
-        [
-          {
-            "node": "Rebuild Context and Set Inference Start",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Rebuild Context and Set Inference Start": {
-      "main": [
-        [
-          {
-            "node": "Generate Initial Response",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Merge LLM Result",
-            "type": "main",
-            "index": 0
           }
         ]
       ]


### PR DESCRIPTION
## Summary
- Migrate Start_Thread from 3 Postgres + 3 Merge nodes to unified Execute_Queries pattern
- Simplify by removing fake parallelism (n8n executes branches sequentially)

## Changes

### Execute_Queries Migration
- **Execute_Queries (Read)**: Fetch north_star config
- **Execute_Queries (Write)**: Insert trace + projection using `$results.trace.row.*` chaining

### Simplification
Removed unnecessary Merge nodes that were combining "parallel" branches:
- `Merge Thread + North Star` (3 inputs) → removed
- `Merge LLM Result` → removed  
- `Merge Trace Result` → removed

### New Sequential Flow
```
Trigger → Create Discord Thread → Prepare Read Queries → Execute_Queries (Read)
        → Build LLM Context → Generate Initial Response → Set LLM Response
        → Send Response to Thread → Prepare Write Queries → Execute_Queries (Write)
        
(fire-and-forget: React 🗨️, Remove 🔵)
```

## Result
- **Nodes**: 17 → 14 (-3)
- **Lines**: -156 lines (247 removed, 91 added)
- Cleaner, more maintainable sequential flow

## Follows
- #46 (Execute_Queries)
- #48, #49, #50 (prior migrations)