### PR TITLE
refactor: migrate Handle_Correction to Execute_Queries pattern

### DIFF
--- a/n8n-workflows/Handle_Correction.json
+++ b/n8n-workflows/Handle_Correction.json
@@ -16,36 +16,47 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "-- Look up the original event that created projections for this message\n-- Also get the emoji mapping config for correction types\nWITH original AS (\n  SELECT \n    e.id as event_id,\n    e.payload->>'discord_message_id' as message_id,\n    e.payload->>'clean_text' as clean_text,\n    e.payload->>'discord_channel_id' as channel_id,\n    e.payload->>'discord_guild_id' as guild_id,\n    e.payload->>'author_login' as author_login,\n    e.payload as original_payload\n  FROM events e\n  WHERE e.payload->>'discord_message_id' = $1\n    AND e.event_type = 'discord_message'\n  ORDER BY e.received_at DESC\n  LIMIT 1\n),\nemoji_config AS (\n  SELECT value FROM config WHERE key = 'emoji_mapping'\n)\nSELECT \n  o.*,\n  ec.value as emoji_mapping\nFROM original o\nCROSS JOIN emoji_config ec;",
-        "options": {
-          "queryReplacement": "={{ $json.ctx.event.message_id }}"
-        }
-      },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
-      "position": [
-        -576,
-        400
-      ],
-      "id": "lookup-original-event",
-      "name": "Lookup Original Event",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      },
-      "alwaysOutputData": true
-    },
-    {
-      "parameters": {
-        "jsCode": "// Prepare correction context\nconst ctx = $('Execute Workflow Trigger').first().json.ctx;\nconst original = $json;\n\nif (!original || !original.event_id) {\n  return {\n    ctx,\n    has_original: false,\n    error: 'No original event found for this message'\n  };\n}\n\n// Parse emoji mapping - Postgres returns JSON as string\nconst rawMapping = original.emoji_mapping;\nconst emojiMapping = typeof rawMapping === 'string' ? JSON.parse(rawMapping) : (rawMapping || {});\nconst types = emojiMapping.types || {};\nconst actions = emojiMapping.actions || {};\nconst emoji = ctx.event.emoji;\n\n// Determine correction type\nlet correctionType = null;\nlet correctionTag = null;\nlet isVoidOnly = false;\n\nif (types[emoji]) {\n  correctionType = types[emoji].type;\n  correctionTag = types[emoji].tag;\n} else if (actions[emoji] === 'void') {\n  isVoidOnly = true;\n}\n\n// Pre-compute values for Postgres queries to avoid n8n expression parsing issues\nconst messageUrl = `https://discord.com/channels/${original.guild_id}/${original.channel_id}/${original.message_id}`;\nconst idempotencyKey = `correction_${original.message_id}_${Date.now()}`;\n\nreturn {\n  ctx,\n  has_original: true,\n  original: {\n    event_id: original.event_id,\n    message_id: original.message_id,\n    clean_text: original.clean_text,\n    channel_id: original.channel_id,\n    guild_id: original.guild_id,\n    author_login: original.author_login,\n    payload: original.original_payload,\n    message_url: messageUrl\n  },\n  correction: {\n    emoji: emoji,\n    type: correctionType,\n    tag: correctionTag,\n    is_void_only: isVoidOnly,\n    idempotency_key: idempotencyKey\n  }\n};"
+        "jsCode": "// Build lookup query for Execute_Queries\nconst ctx = $json.ctx;\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      db_queries: [{\n        key: 'original',\n        sql: `-- Look up the original event that created projections for this message\n-- Also get the emoji mapping config for correction types\nWITH original AS (\n  SELECT \n    e.id as event_id,\n    e.payload->>'discord_message_id' as message_id,\n    e.payload->>'clean_text' as clean_text,\n    e.payload->>'discord_channel_id' as channel_id,\n    e.payload->>'discord_guild_id' as guild_id,\n    e.payload->>'author_login' as author_login,\n    e.payload as original_payload\n  FROM events e\n  WHERE e.payload->>'discord_message_id' = $1\n    AND e.event_type = 'discord_message'\n  ORDER BY e.received_at DESC\n  LIMIT 1\n),\nemoji_config AS (\n  SELECT value FROM config WHERE key = 'emoji_mapping'\n)\nSELECT \n  o.*,\n  ec.value as emoji_mapping\nFROM original o\nCROSS JOIN emoji_config ec;`,\n        params: [ctx.event.message_id]\n      }]\n    }\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
+        -576,
+        400
+      ],
+      "id": "build-lookup-query",
+      "name": "Build Lookup Query"
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {}
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [
         -352,
+        400
+      ],
+      "id": "lookup-original-event",
+      "name": "Lookup Original Event"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare correction context from lookup result\nconst ctx = $json.ctx;\nconst original = ctx.db?.original?.row;\n\nif (!original || !original.event_id) {\n  return {\n    ctx,\n    has_original: false,\n    error: 'No original event found for this message'\n  };\n}\n\n// Parse emoji mapping - Postgres returns JSON as string\nconst rawMapping = original.emoji_mapping;\nconst emojiMapping = typeof rawMapping === 'string' ? JSON.parse(rawMapping) : (rawMapping || {});\nconst types = emojiMapping.types || {};\nconst actions = emojiMapping.actions || {};\nconst emoji = ctx.event.emoji;\n\n// Determine correction type\nlet correctionType = null;\nlet correctionTag = null;\nlet isVoidOnly = false;\n\nif (types[emoji]) {\n  correctionType = types[emoji].type;\n  correctionTag = types[emoji].tag;\n} else if (actions[emoji] === 'void') {\n  isVoidOnly = true;\n}\n\n// Pre-compute values for Postgres queries to avoid n8n expression parsing issues\nconst messageUrl = `https://discord.com/channels/${original.guild_id}/${original.channel_id}/${original.message_id}`;\nconst idempotencyKey = `correction_${original.message_id}_${Date.now()}`;\n\nreturn {\n  ctx,\n  has_original: true,\n  original: {\n    event_id: original.event_id,\n    message_id: original.message_id,\n    clean_text: original.clean_text,\n    channel_id: original.channel_id,\n    guild_id: original.guild_id,\n    author_login: original.author_login,\n    payload: original.original_payload,\n    message_url: messageUrl\n  },\n  correction: {\n    emoji: emoji,\n    type: correctionType,\n    tag: correctionTag,\n    is_void_only: isVoidOnly,\n    idempotency_key: idempotencyKey\n  }\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -128,
         400
       ],
       "id": "prepare-correction",
@@ -79,7 +90,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        -128,
+        96,
         400
       ],
       "id": "has-original-check",
@@ -87,64 +98,85 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "-- Create correction event for audit trail\nINSERT INTO events (idempotency_key, event_type, payload)\nVALUES (\n  $1,\n  'user_correction',\n  jsonb_build_object(\n    'original_event_id', $2,\n    'original_message_id', $3,\n    'correction_emoji', $4,\n    'correction_type', $5,\n    'is_void_only', $6,\n    'triggered_by_event_id', $7\n  )\n)\nON CONFLICT (event_type, idempotency_key) DO NOTHING\nRETURNING id;",
-        "options": {
-          "queryReplacement": "={{ $json.correction.idempotency_key }},={{ $json.original.event_id }},={{ $json.original.message_id }},={{ $json.correction.emoji }},={{ $json.correction.type || 'void' }},={{ $json.correction.is_void_only }},={{ $json.ctx.event.event_id }}"
-        }
-      },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
-      "position": [
-        96,
-        336
-      ],
-      "id": "create-correction-event",
-      "name": "Create Correction Event",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      },
-      "alwaysOutputData": true
-    },
-    {
-      "parameters": {
-        "operation": "executeQuery",
-        "query": "-- Void ALL projections for this Discord message (by message_url)\n-- This catches both original projections and any corrected ones\nUPDATE projections\nSET \n  status = 'voided',\n  voided_at = NOW(),\n  voided_reason = 'user_correction',\n  voided_by_event_id = $1::uuid\nWHERE data->>'message_url' = $2\n  AND status IN ('pending', 'auto_confirmed', 'confirmed')\nRETURNING id, projection_type, data->>'description' as description, data->>'text' as text;",
-        "options": {
-          "queryReplacement": "={{ $json.id }},={{ $('Prepare Correction').first().json.original.message_url }}"
-        }
-      },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
-      "position": [
-        320,
-        336
-      ],
-      "id": "void-projections",
-      "name": "Void Projections",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      },
-      "alwaysOutputData": true
-    },
-    {
-      "parameters": {
-        "jsCode": "// Build list of emojis to remove based on voided projection types\nconst prepareData = $('Prepare Correction').first().json;\nconst channelId = prepareData.original.channel_id;\nconst messageId = prepareData.original.message_id;\n\n// Get voided projection types from Void Projections result\nconst voidedItems = $('Void Projections').all();\nconst voidedTypes = voidedItems.map(item => item.json.projection_type).filter(Boolean);\n\n// Map projection types to their emojis\nconst typeToEmoji = {\n  'activity': '🔘',\n  'note': '📝',\n  'todo': '✅'\n};\n\n// Only remove emojis for the projection types that were actually voided\nconst emojisToRemove = [...new Set(voidedTypes.map(t => typeToEmoji[t]).filter(Boolean))];\n\nif (emojisToRemove.length === 0) {\n  // No emojis to remove, return skip marker\n  return [{ json: { skip: true } }];\n}\n\nreturn emojisToRemove.map(emoji => ({\n  json: {\n    channel_id: channelId,\n    message_id: messageId,\n    emoji: emoji,\n    encoded_emoji: encodeURIComponent(emoji),\n    skip: false\n  }\n}));"
+        "jsCode": "// Build queries for correction event creation and voiding projections\n// Uses $results chaining: correction event id -> void projections\nconst data = $json;\nconst ctx = data.ctx;\nconst original = data.original;\nconst correction = data.correction;\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      db_queries: [\n        {\n          key: 'correction_event',\n          sql: `-- Create correction event for audit trail\nINSERT INTO events (idempotency_key, event_type, payload)\nVALUES (\n  $1,\n  'user_correction',\n  jsonb_build_object(\n    'original_event_id', $2,\n    'original_message_id', $3,\n    'correction_emoji', $4,\n    'correction_type', $5,\n    'is_void_only', $6,\n    'triggered_by_event_id', $7\n  )\n)\nON CONFLICT (event_type, idempotency_key) DO NOTHING\nRETURNING id;`,\n          params: [\n            correction.idempotency_key,\n            original.event_id,\n            original.message_id,\n            correction.emoji,\n            correction.type || 'void',\n            correction.is_void_only,\n            ctx.event.event_id\n          ]\n        },\n        {\n          key: 'voided',\n          sql: `-- Void ALL projections for this Discord message (by message_url)\n-- This catches both original projections and any corrected ones\nUPDATE projections\nSET \n  status = 'voided',\n  voided_at = NOW(),\n  voided_reason = 'user_correction',\n  voided_by_event_id = $1::uuid\nWHERE data->>'message_url' = $2\n  AND status IN ('pending', 'auto_confirmed', 'confirmed')\nRETURNING id, projection_type, data->>'description' as description, data->>'text' as text;`,\n          params: [\n            '$results.correction_event.row.id',\n            original.message_url\n          ]\n        }\n      ]\n    },\n    original: original,\n    correction: correction\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
+        320,
+        336
+      ],
+      "id": "build-correction-queries",
+      "name": "Build Correction Queries"
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {}
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [
         544,
+        336
+      ],
+      "id": "execute-correction-queries",
+      "name": "Execute Correction Queries"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build list of emojis to remove based on voided projection types\nconst ctx = $json.ctx;\nconst original = $('Build Correction Queries').first().json.original;\nconst channelId = original.channel_id;\nconst messageId = original.message_id;\n\n// Get voided projection types from Execute_Queries result\nconst voidedRows = ctx.db?.voided?.rows || [];\nconst voidedTypes = voidedRows.map(item => item.projection_type).filter(Boolean);\n\n// Map projection types to their emojis\nconst typeToEmoji = {\n  'activity': '🔘',\n  'note': '📝',\n  'todo': '✅'\n};\n\n// Only remove emojis for the projection types that were actually voided\nconst emojisToRemove = [...new Set(voidedTypes.map(t => typeToEmoji[t]).filter(Boolean))];\n\nif (emojisToRemove.length === 0) {\n  // No emojis to remove, return skip marker\n  return [{ json: { skip: true, ctx } }];\n}\n\nreturn emojisToRemove.map(emoji => ({\n  json: {\n    channel_id: channelId,\n    message_id: messageId,\n    emoji: emoji,\n    encoded_emoji: encodeURIComponent(emoji),\n    skip: false,\n    ctx\n  }\n}));"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        768,
         336
       ],
       "id": "build-emoji-remove-list",
       "name": "Build Emoji Remove List"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "not-skip",
+              "leftValue": "={{ $json.skip }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "false",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        880,
+        336
+      ],
+      "id": "filter-skip",
+      "name": "Has Emoji to Remove?"
     },
     {
       "parameters": {
@@ -157,8 +189,8 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        880,
-        336
+        1104,
+        272
       ],
       "id": "remove-bot-emojis",
       "name": "Remove Bot Emojis",
@@ -173,12 +205,12 @@
     },
     {
       "parameters": {
-        "jsCode": "// After removing emojis, check if we need to re-extract or just void\nconst prepareData = $('Prepare Correction').first().json;\nconst correctionEventResult = $('Create Correction Event').first().json;\n\n// Collect voided projection IDs for linking to new projection\nconst voidedItems = $('Void Projections').all();\nconst voidedProjectionIds = voidedItems.map(item => item.json.id).filter(Boolean);\n\nreturn {\n  ctx: prepareData.ctx,\n  original: prepareData.original,\n  correction: prepareData.correction,\n  correction_event_id: correctionEventResult.id,\n  voided_projection_ids: voidedProjectionIds,\n  should_reextract: !prepareData.correction.is_void_only && !!prepareData.correction.type\n};"
+        "jsCode": "// After removing emojis, check if we need to re-extract or just void\nconst prepareData = $('Build Correction Queries').first().json;\nconst ctx = $('Execute Correction Queries').first().json.ctx;\n\n// Get correction event ID from Execute_Queries result\nconst correctionEventId = ctx.db?.correction_event?.row?.id;\n\n// Collect voided projection IDs for linking to new projection\nconst voidedRows = ctx.db?.voided?.rows || [];\nconst voidedProjectionIds = voidedRows.map(item => item.id).filter(Boolean);\n\nreturn {\n  ctx,\n  original: prepareData.original,\n  correction: prepareData.correction,\n  correction_event_id: correctionEventId,\n  voided_projection_ids: voidedProjectionIds,\n  should_reextract: !prepareData.correction.is_void_only && !!prepareData.correction.type\n};"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1104,
+        1328,
         336
       ],
       "id": "check-reextract",
@@ -212,7 +244,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        1328,
+        1552,
         336
       ],
       "id": "should-reextract-check",
@@ -225,7 +257,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1552,
+        1776,
         272
       ],
       "id": "build-capture-ctx",
@@ -249,7 +281,7 @@
       "type": "n8n-nodes-base.executeWorkflow",
       "typeVersion": 1.3,
       "position": [
-        1776,
+        2000,
         272
       ],
       "id": "execute-capture",
@@ -260,7 +292,7 @@
         "resource": "message",
         "guildId": {
           "__rl": true,
-          "value": "={{ $('Prepare Correction').first().json.original.guild_id }}",
+          "value": "={{ $('Build Correction Queries').first().json.original.guild_id }}",
           "mode": "id"
         },
         "channelId": {
@@ -268,13 +300,13 @@
           "value": "={{ $env.DISCORD_CHANNEL_KAIRON_LOGS }}",
           "mode": "id"
         },
-        "content": "=**[Correction]** {{ $('Prepare Correction').first().json.correction.is_void_only ? 'Voided' : 'Re-extracted as ' + $('Prepare Correction').first().json.correction.type }} for message `{{ $('Prepare Correction').first().json.original.message_id }}`",
+        "content": "=**[Correction]** {{ $('Build Correction Queries').first().json.correction.is_void_only ? 'Voided' : 'Re-extracted as ' + $('Build Correction Queries').first().json.correction.type }} for message `{{ $('Build Correction Queries').first().json.original.message_id }}`",
         "options": {}
       },
       "type": "n8n-nodes-base.discord",
       "typeVersion": 2,
       "position": [
-        1776,
+        2000,
         464
       ],
       "id": "log-correction",
@@ -310,7 +342,7 @@
       "type": "n8n-nodes-base.discord",
       "typeVersion": 2,
       "position": [
-        96,
+        320,
         560
       ],
       "id": "log-no-original",
@@ -326,44 +358,21 @@
         }
       },
       "onError": "continueRegularOutput"
-    },
-    {
-      "parameters": {
-        "conditions": {
-          "options": {
-            "caseSensitive": true,
-            "leftValue": "",
-            "typeValidation": "strict",
-            "version": 2
-          },
-          "conditions": [
-            {
-              "id": "not-skip",
-              "leftValue": "={{ $json.skip }}",
-              "rightValue": false,
-              "operator": {
-                "type": "boolean",
-                "operation": "false",
-                "singleValue": true
-              }
-            }
-          ],
-          "combinator": "and"
-        },
-        "options": {}
-      },
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [
-        656,
-        336
-      ],
-      "id": "filter-skip",
-      "name": "Has Emoji to Remove?"
     }
   ],
   "connections": {
     "Execute Workflow Trigger": {
+      "main": [
+        [
+          {
+            "node": "Build Lookup Query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Lookup Query": {
       "main": [
         [
           {
@@ -400,7 +409,7 @@
       "main": [
         [
           {
-            "node": "Create Correction Event",
+            "node": "Build Correction Queries",
             "type": "main",
             "index": 0
           }
@@ -414,18 +423,18 @@
         ]
       ]
     },
-    "Create Correction Event": {
+    "Build Correction Queries": {
       "main": [
         [
           {
-            "node": "Void Projections",
+            "node": "Execute Correction Queries",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Void Projections": {
+    "Execute Correction Queries": {
       "main": [
         [
           {
@@ -441,6 +450,24 @@
         [
           {
             "node": "Has Emoji to Remove?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Emoji to Remove?": {
+      "main": [
+        [
+          {
+            "node": "Remove Bot Emojis",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Check Re-extract",
             "type": "main",
             "index": 0
           }
@@ -492,24 +519,6 @@
         [
           {
             "node": "Execute Capture_Projection",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Has Emoji to Remove?": {
-      "main": [
-        [
-          {
-            "node": "Remove Bot Emojis",
-            "type": "main",
-            "index": 0
-          }
-        ],
-        [
-          {
-            "node": "Check Re-extract",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- Replace 3 Postgres nodes with 2 Execute_Queries sub-workflow calls
- Use `$results` chaining: correction event INSERT returns id, which is then used by void projections UPDATE

## Changes
- **Lookup Original Event**: Single Execute_Queries call, result in `ctx.db.original`
- **Create Correction Event + Void Projections**: Combined into one Execute_Queries call with `$results.correction_event.row.id` chaining
- Results stored in `ctx.db.correction_event` and `ctx.db.voided`

## Node Changes
- Before: 15 nodes (3 postgres)
- After: 16 nodes (0 postgres, 2 executeWorkflow)

Part of the Execute_Queries migration series (#46).