### PR TITLE
refactor: migrate Capture_Projection to Execute_Queries pattern

### DIFF
--- a/n8n-workflows/Capture_Projection.json
+++ b/n8n-workflows/Capture_Projection.json
@@ -280,7 +280,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse LLM classification output and prepare for storage\nconst llmText = $json.text?.trim() || '';\nconst routingItem = $('Prepare Routing').first().json;\nconst ctx = routingItem.ctx;\nconst projectionType = routingItem.projection_type;\nconst inferenceStart = routingItem.inference_start;\nconst durationMs = Date.now() - inferenceStart;\n\n// Format trace_chain for PostgreSQL uuid[] type\nconst traceChain = ctx.event.trace_chain || [];\nconst traceChainPg = '{' + traceChain.join(',') + '}';\n\n// Get voided projection IDs from correction context (if this is a correction)\nconst voidedProjectionIds = ctx.correction?.voided_projection_ids || [];\nconst voidedProjectionIdsPg = voidedProjectionIds.length > 0 \n  ? '{' + voidedProjectionIds.join(',') + '}' \n  : null;\n\n// Default categories/priorities per type\nconst defaults = {\n  activity: 'work',\n  note: 'reflection',\n  todo: 'medium'\n};\n\n// Parse scores from LLM output\nconst scores = {};\nlet topResult = null;\nlet topScore = 0;\n\ntry {\n  const lines = llmText.split('\\n').filter(line => line.includes('|'));\n  lines.forEach(line => {\n    const [key, scoreStr] = line.split('|').map(s => s.trim());\n    const score = parseInt(scoreStr);\n    if (!isNaN(score)) {\n      scores[key] = score;\n      if (score > topScore) {\n        topScore = score;\n        topResult = key;\n      }\n    }\n  });\n} catch (e) {\n  // Use default on parse error\n}\n\nif (!topResult) {\n  topResult = defaults[projectionType];\n  topScore = 50;\n}\n\n// Build projection data based on type\nlet projectionData;\nif (projectionType === 'activity') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    category: topResult,\n    description: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores\n  };\n} else if (projectionType === 'note') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    category: topResult,\n    text: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores\n  };\n} else if (projectionType === 'todo') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    priority: topResult,\n    description: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores,\n    status: 'pending'\n  };\n}\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      llm: {\n        result: topResult,\n        confidence: topScore / 100,\n        all_scores: scores,\n        completion_text: llmText,\n        duration_ms: durationMs\n      }\n    },\n    projection_type: projectionType,\n    projection_data: projectionData,\n    // Flat fields for trace/projection INSERT\n    event_id: ctx.event.event_id,\n    input_text: ctx.event.clean_text,\n    completion_text: llmText,\n    result: topResult,\n    confidence: topScore / 100,\n    all_scores_json: JSON.stringify(scores),\n    duration_ms: durationMs,\n    trace_chain_pg: traceChainPg,\n    projection_data_json: JSON.stringify(projectionData),\n    voided_projection_ids_pg: voidedProjectionIdsPg\n  }\n}];"
+        "jsCode": "// Parse LLM classification output and build query for Execute_Queries\nconst llmText = $json.text?.trim() || '';\nconst routingItem = $('Prepare Routing').first().json;\nconst ctx = routingItem.ctx;\nconst projectionType = routingItem.projection_type;\nconst inferenceStart = routingItem.inference_start;\nconst durationMs = Date.now() - inferenceStart;\n\n// Format trace_chain for PostgreSQL uuid[] type\nconst traceChain = ctx.event.trace_chain || [];\nconst traceChainPg = '{' + traceChain.join(',') + '}';\n\n// Get voided projection IDs from correction context (if this is a correction)\nconst voidedProjectionIds = ctx.correction?.voided_projection_ids || [];\nconst voidedProjectionIdsPg = voidedProjectionIds.length > 0 \n  ? '{' + voidedProjectionIds.join(',') + '}' \n  : null;\n\n// Default categories/priorities per type\nconst defaults = {\n  activity: 'work',\n  note: 'reflection',\n  todo: 'medium'\n};\n\n// Parse scores from LLM output\nconst scores = {};\nlet topResult = null;\nlet topScore = 0;\n\ntry {\n  const lines = llmText.split('\\n').filter(line => line.includes('|'));\n  lines.forEach(line => {\n    const [key, scoreStr] = line.split('|').map(s => s.trim());\n    const score = parseInt(scoreStr);\n    if (!isNaN(score)) {\n      scores[key] = score;\n      if (score > topScore) {\n        topScore = score;\n        topResult = key;\n      }\n    }\n  });\n} catch (e) {\n  // Use default on parse error\n}\n\nif (!topResult) {\n  topResult = defaults[projectionType];\n  topScore = 50;\n}\n\n// Build projection data based on type\nlet projectionData;\nif (projectionType === 'activity') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    category: topResult,\n    description: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores\n  };\n} else if (projectionType === 'note') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    category: topResult,\n    text: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores\n  };\n} else if (projectionType === 'todo') {\n  projectionData = {\n    timestamp: new Date().toISOString(),\n    priority: topResult,\n    description: ctx.event.clean_text,\n    message_url: ctx.event.message_url,\n    confidence: topScore / 100,\n    all_scores: scores,\n    status: 'pending'\n  };\n}\n\nreturn [{\n  json: {\n    ctx: {\n      ...ctx,\n      llm: {\n        result: topResult,\n        confidence: topScore / 100,\n        all_scores: scores,\n        completion_text: llmText,\n        duration_ms: durationMs\n      },\n      db_queries: [{\n        key: 'projection',\n        sql: `WITH new_trace AS (\n  INSERT INTO traces (event_id, step_name, data, trace_chain)\n  VALUES (\n    $1::uuid,\n    $2 || '_classification',\n    jsonb_build_object(\n      'input', jsonb_build_object('text', $3),\n      'completion', $4,\n      'result', jsonb_build_object(\n        'value', $5,\n        'confidence', $6::numeric,\n        'all_scores', $7::jsonb\n      ),\n      'model', 'xiaomi/mimo-v2-flash:free',\n      'duration_ms', $8::integer\n    ),\n    $9::uuid[]\n  )\n  RETURNING id, event_id\n),\nnew_projection AS (\n  INSERT INTO projections (\n    trace_id,\n    event_id,\n    trace_chain,\n    projection_type,\n    data,\n    status,\n    timezone,\n    supersedes_projection_id\n  )\n  SELECT\n    new_trace.id,\n    new_trace.event_id,\n    $9::uuid[] || new_trace.id,\n    $2,\n    $10::jsonb,\n    'auto_confirmed',\n    $11,\n    CASE WHEN $12::uuid[] IS NOT NULL AND array_length($12::uuid[], 1) > 0 THEN ($12::uuid[])[1] ELSE NULL END\n  FROM new_trace\n  RETURNING *\n),\nupdate_voided AS (\n  UPDATE projections\n  SET superseded_by_projection_id = (SELECT id FROM new_projection)\n  WHERE id = ANY($12::uuid[])\n  RETURNING id\n)\nSELECT np.*, COALESCE((SELECT array_agg(id) FROM update_voided), ARRAY[]::uuid[]) as linked_voided_ids\nFROM new_projection np;`,\n        params: [\n          ctx.event.event_id,\n          projectionType,\n          ctx.event.clean_text,\n          llmText,\n          topResult,\n          topScore / 100,\n          JSON.stringify(scores),\n          durationMs,\n          traceChainPg,\n          JSON.stringify(projectionData),\n          ctx.event.timezone,\n          voidedProjectionIdsPg\n        ]\n      }]\n    },\n    projection_type: projectionType,\n    projection_data: projectionData\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -293,26 +293,25 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "WITH new_trace AS (\n  INSERT INTO traces (event_id, step_name, data, trace_chain)\n  VALUES (\n    $1::uuid,\n    $2 || '_classification',\n    jsonb_build_object(\n      'input', jsonb_build_object('text', $3),\n      'completion', $4,\n      'result', jsonb_build_object(\n        'value', $5,\n        'confidence', $6::numeric,\n        'all_scores', $7::jsonb\n      ),\n      'model', 'xiaomi/mimo-v2-flash:free',\n      'duration_ms', $8::integer\n    ),\n    $9::uuid[]\n  )\n  RETURNING id, event_id\n),\nnew_projection AS (\n  INSERT INTO projections (\n    trace_id,\n    event_id,\n    trace_chain,\n    projection_type,\n    data,\n    status,\n    timezone,\n    supersedes_projection_id\n  )\n  SELECT\n    new_trace.id,\n    new_trace.event_id,\n    $9::uuid[] || new_trace.id,\n    $2,\n    $10::jsonb,\n    'auto_confirmed',\n    $11,\n    CASE WHEN $12::uuid[] IS NOT NULL AND array_length($12::uuid[], 1) > 0 THEN ($12::uuid[])[1] ELSE NULL END\n  FROM new_trace\n  RETURNING *\n),\nupdate_voided AS (\n  UPDATE projections\n  SET superseded_by_projection_id = (SELECT id FROM new_projection)\n  WHERE id = ANY($12::uuid[])\n  RETURNING id\n)\nSELECT np.*, COALESCE((SELECT array_agg(id) FROM update_voided), ARRAY[]::uuid[]) as linked_voided_ids\nFROM new_projection np;",
-        "options": {
-          "queryReplacement": "={{ $json.event_id }},={{ $json.projection_type }},={{ $json.input_text }},={{ $json.completion_text }},={{ $json.result }},={{ $json.confidence }},={{ $json.all_scores_json }},={{ $json.duration_ms }},={{ $json.trace_chain_pg }},={{ $json.projection_data_json }},={{ $json.ctx.event.timezone }},={{ $json.voided_projection_ids_pg }}"
-        }
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {}
+        },
+        "options": {}
       },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
       "position": [
         -128,
         704
       ],
       "id": "store-projection",
-      "name": "Store Projection",
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      }
+      "name": "Store Projection"
     },
     {
       "parameters": {
@@ -327,7 +326,7 @@
           "value": "={{ $env.DISCORD_CHANNEL_KAIRON_LOGS }}",
           "mode": "id"
         },
-        "content": "=**[{{ $('Parse Classification').item.json.projection_type.charAt(0).toUpperCase() + $('Parse Classification').item.json.projection_type.slice(1) }} Classification]**\n**Message:** {{ $('Parse Classification').item.json.ctx.event.clean_text }}\n**Result:** {{ $('Parse Classification').item.json.result }}\n**Confidence:** [ {{ Object.entries($('Parse Classification').item.json.ctx.llm.all_scores || {}).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}:${v}%`).join(' | ') }} ]",
+        "content": "=**[{{ $('Parse Classification').item.json.projection_type.charAt(0).toUpperCase() + $('Parse Classification').item.json.projection_type.slice(1) }} Classification]**\n**Message:** {{ $('Parse Classification').item.json.ctx.event.clean_text }}\n**Result:** {{ $('Parse Classification').item.json.ctx.llm.result }}\n**Confidence:** [ {{ Object.entries($('Parse Classification').item.json.ctx.llm.all_scores || {}).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}:${v}%`).join(' | ') }} ]",
         "options": {}
       },
       "type": "n8n-nodes-base.discord",
@@ -352,7 +351,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Extract text for embedding from projection data\n// Activity uses 'description', Note/Todo use 'text'\nconst projection = $json;\nconst data = projection.data || {};\nconst embeddingText = data.description || data.text || '';\n\nreturn [{\n  json: {\n    projection_id: projection.id,\n    embedding_text: embeddingText\n  }\n}];"
+        "jsCode": "// Extract text for embedding from projection data\n// Activity uses 'description', Note/Todo use 'text'\nconst ctx = $json.ctx;\nconst projection = ctx.db?.projection?.row || {};\nconst data = projection.data || {};\nconst embeddingText = data.description || data.text || '';\n\nreturn [{\n  json: {\n    projection_id: projection.id,\n    embedding_text: embeddingText\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -386,27 +385,39 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "-- Insert embedding for the projection (fire-and-forget)\nINSERT INTO embeddings (projection_id, model, embedding_data, embedded_text, embedding)\nSELECT \n  $1::uuid,\n  'all-MiniLM-L6-v2',\n  '{}',\n  $2,\n  $3::vector\nWHERE $3 IS NOT NULL\nON CONFLICT DO NOTHING;",
-        "options": {
-          "queryReplacement": "={{ $('Prepare Embedding Text').first().json.projection_id }},={{ $('Prepare Embedding Text').first().json.embedding_text }},={{ $json.embeddings && $json.embeddings[0] ? '[' + $json.embeddings[0].join(',') + ']' : null }}"
-        }
+        "jsCode": "// Build embedding insert query for Execute_Queries\nconst prepareData = $('Prepare Embedding Text').first().json;\nconst embeddings = $json.embeddings;\n\n// Check if we have a valid embedding\nif (!embeddings || !embeddings[0]) {\n  return [];  // Skip if no embedding\n}\n\nconst embeddingVector = '[' + embeddings[0].join(',') + ']';\n\nreturn [{\n  json: {\n    ctx: {\n      db_queries: [{\n        key: 'embedding',\n        sql: `-- Insert embedding for the projection (fire-and-forget)\nINSERT INTO embeddings (projection_id, model, embedding_data, embedded_text, embedding)\nSELECT \n  $1::uuid,\n  'all-MiniLM-L6-v2',\n  '{}',\n  $2,\n  $3::vector\nWHERE $3 IS NOT NULL\nON CONFLICT DO NOTHING;`,\n        params: [\n          prepareData.projection_id,\n          prepareData.embedding_text,\n          embeddingVector\n        ]\n      }]\n    }\n  }\n}];"
       },
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.4,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
         544,
         496
       ],
+      "id": "build-embedding-query",
+      "name": "Build Embedding Query"
+    },
+    {
+      "parameters": {
+        "workflowId": {
+          "__rl": true,
+          "value": "={{ $env.WORKFLOW_ID_EXECUTE_QUERIES }}",
+          "mode": "id"
+        },
+        "workflowInputs": {
+          "mappingMode": "defineBelow",
+          "value": {}
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.executeWorkflow",
+      "typeVersion": 1.3,
+      "position": [
+        768,
+        496
+      ],
       "id": "insert-embedding",
       "name": "Insert Embedding",
-      "continueOnFail": true,
-      "credentials": {
-        "postgres": {
-          "id": "MdnYzEgjzWRujz2v",
-          "name": "Postgres account"
-        }
-      }
+      "continueOnFail": true
     }
   ],
   "connections": {
@@ -557,6 +568,17 @@
       ]
     },
     "Embed Projection Text": {
+      "main": [
+        [
+          {
+            "node": "Build Embedding Query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Embedding Query": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- Replace 2 Postgres nodes with 2 Execute_Queries sub-workflow calls
- Standardize all DB access through unified sub-workflow

## Changes
- **Store Projection**: Complex CTE query (trace + projection + update voided) now in `ctx.db_queries`
  - Result stored in `ctx.db.projection.row`
- **Insert Embedding**: Query builder node after embedding HTTP call
  - Gracefully skips if no embedding returned
  - Result stored in `ctx.db.embedding`

## Node Changes
- Before: 17 nodes (2 postgres)
- After: 18 nodes (0 postgres, 2 executeWorkflow for Execute_Queries)

Part of the Execute_Queries migration series (#46).