### PR TITLE
fix: Handle unbound variables in deploy.sh (HOTFIX)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -321,11 +321,11 @@ deploy_dev() {
     # Get existing dev workflow IDs and validate count
     local DEV_WORKFLOW_IDS
     local WORKFLOW_COUNT
-    if [ -n "$N8N_DEV_COOKIE_FILE" ] && [ -f "$N8N_DEV_COOKIE_FILE" ]; then
+    if [ -n "${N8N_DEV_COOKIE_FILE:-}" ] && [ -f "${N8N_DEV_COOKIE_FILE}" ]; then
         local RESPONSE=$(curl -s -b "$N8N_DEV_COOKIE_FILE" "$API_URL/rest/workflows?take=100")
         DEV_WORKFLOW_IDS=$(echo "$RESPONSE" | jq -c '[.data[]? | {(.name): .id}] | add // {}')
         WORKFLOW_COUNT=$(echo "$RESPONSE" | jq '.data | length')
-    elif [ -n "$API_KEY" ]; then
+    elif [ -n "${API_KEY:-}" ]; then
         local RESPONSE=$(curl -s -H "X-N8N-API-KEY: $API_KEY" "$API_URL/rest/workflows?take=100")
         DEV_WORKFLOW_IDS=$(echo "$RESPONSE" | jq -c '[.data[]? | {(.name): .id}] | add // {}')
         WORKFLOW_COUNT=$(echo "$RESPONSE" | jq '.data | length')


### PR DESCRIPTION
## CRITICAL HOTFIX

This fixes the pre-push hook failure that allowed PR #107 to be merged without proper testing.

## Problem

The pre-push hook failed with:
```
/home/chris/Work/kairon/scripts/deploy.sh: line 324: N8N_DEV_COOKIE_FILE: unbound variable
```

This caused the deployment pipeline to be bypassed, allowing untested code to reach main.

## Root Cause

- Script uses `set -euo pipefail` which fails on unbound variables
- Lines 324 and 328 checked variables without the `${VAR:-}` syntax
- This code was introduced in PR #106 but wasn't properly tested

## Changes

```bash
# Before (line 324)
if [ -n "$N8N_DEV_COOKIE_FILE" ] && [ -f "$N8N_DEV_COOKIE_FILE" ]; then

# After
if [ -n "${N8N_DEV_COOKIE_FILE:-}" ] && [ -f "${N8N_DEV_COOKIE_FILE}" ]; then
```

Same fix applied to `API_KEY` check on line 328.

## Testing

- ✅ Pre-push hook now completes successfully (no workflow changes detected)
- Ready to test full pipeline after merge

## Impact

This unblocks:
1. Proper testing of PR #107 changes (currently untested in production)
2. Future deployments through the pre-push hook
3. CI/CD pipeline functionality

## Urgency

**CRITICAL** - Without this fix:
- Developers can accidentally bypass safety checks
- Untested code can reach production
- The deployment pipeline is non-functional